### PR TITLE
fix: missing 'type' keyword for MongoDB provider

### DIFF
--- a/languages/prisma/highlights.scm
+++ b/languages/prisma/highlights.scm
@@ -4,6 +4,7 @@
  "generator"
  "model"
  "view"
+ "type"
 ] @keyword
 
 (comment) @comment


### PR DESCRIPTION
This pull request includes a small change to the `languages/prisma/highlights.scm` file. The change adds the keyword "type" to the list of recognized keywords for syntax highlighting.

* [`languages/prisma/highlights.scm`](diffhunk://#diff-fed69e449f50e44dca5e1342df6361cddba6d71f9e171a33e0f04fbee68d639fR7): Added the keyword "type" to the list of recognized keywords for syntax highlighting.