### PR TITLE
chore:  type highlighting support

### DIFF
--- a/languages/prisma/highlights.scm
+++ b/languages/prisma/highlights.scm
@@ -4,6 +4,7 @@
  "generator"
  "model"
  "view"
+ "type"
 ] @keyword
 
 (comment) @comment
@@ -18,6 +19,10 @@
 (call_expression (identifier) @function)
 (enumeral) @constant
 (identifier) @variable
+(column_type (identifier) @type)
+(column_type (call_expression (identifier) @type))
+(type_declaration_type) @type
+(type_declaration (identifier) @type.definition)
 (column_declaration (identifier) (column_type (identifier) @type))
 (attribute (identifier) @label)
 (attribute (call_expression (identifier) @label))


### PR DESCRIPTION
Closes #3 

This PR improves syntax highlighting for type-related constructs in Prisma schema files by expanding the existing type highlighting patterns and adding support for the `type` keyword.

### Changes
- **Added `type` keyword highlighting** - The `type` keyword used in type declarations is now properly highlighted
- **Enhanced type pattern matching**:
  - `(column_type (identifier) @type)` - Highlights basic type names (e.g., `String`, `Int`, `Boolean`)
  - `(column_type (call_expression (identifier) @type))` - Highlights function-based types with parameters (e.g., `Decimal(10,2)`, `VarChar(255)`)
  - `(type_declaration_type) @type` - Highlights type aliases in type declarations
  - `(type_declaration (identifier) @type.definition)` - Highlights type names being defined
  
### Impact
This enhancement provides better visual distinction for:
- Built-in Prisma types (`String`, `Int`, `DateTime`, etc.)
- Custom type declarations and aliases
- Parameterized types with function-like syntax
- Type definitions in custom type declarations


### Before
<img width="582" height="337" alt="image" src="https://github.com/user-attachments/assets/53b51a73-2731-4210-a9d9-50363f7c595e" />


### After
<img width="380" height="287" alt="image" src="https://github.com/user-attachments/assets/351ff702-e3f2-40e4-b39f-3f4a4879099f" />
